### PR TITLE
Examples : change instance type from `x5.large` to `t3.medium`

### DIFF
--- a/examples/private_cluster/eks.tf
+++ b/examples/private_cluster/eks.tf
@@ -56,7 +56,7 @@ module "eks_private" {
       max_size       = 2
       desired_size   = 1
       ami_type       = "AL2_x86_64"
-      instance_types = ["m5.large"]
+      instance_types = ["t3.medium"]
     }
   }
 


### PR DESCRIPTION
For cost-saving purposes updated the instance type `x5.large` to `t3.medium` in the private cluster example 
closes #2 